### PR TITLE
Use the newer compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,15 +39,17 @@ matrix:
         - MATRIX_EVAL="CMAKE_GENERATOR='Unix Makefiles' && CXX=clang++-10"
     - name: Clang 10 on macOS
       os: osx
-      osx_image: xcode10.3 # this image has CLang 10.0.1 (same as Linux) and CMake 3.15
+      osx_image: xcode12.2 # this image has Clang >10.0.1 and CMake >3.15
       env:
         - MATRIX_EVAL="CMAKE_GENERATOR='Unix Makefiles' && CXX=clang++"
-    - name: MSVC 2017 on Windows
+    - name: MSVC 2019 on Windows
       os: windows
       env:
-        - MATRIX_EVAL="CMAKE_GENERATOR='Visual Studio 15 2017'"
+        - MATRIX_EVAL="CMAKE_GENERATOR='Visual Studio 16 2019'"
 before_install:
   - eval "${MATRIX_EVAL}"
+install:
+  - if [ $TRAVIS_OS_NAME = 'windows' ]; then choco install visualstudio2019buildtools --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64"; fi
 before_script:
   - cd build
   - cmake -G "$CMAKE_GENERATOR" ..

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A template for a cross-platform C++20 project including CMake, unit-testing with
 - Travis-CI config file supporting building and running tests on Linux, macOS and Windows using the following compilers:
     - Linux: GCC-10, Clang-10
     - macOS: Clang-10
-    - Windows: MSVC 2017
+    - Windows: MSVC 2019
     - 1 Additional build on Linux to check Doxygen documentation is well-formed
 - Doxygen config file with tweaks from the default config settings to provide a few more graphs (usage, caller/callee relationships) than are enabled by default.
 


### PR DESCRIPTION
- MSVC 2019 (no longer complains about using the alternative tokens)
- Newer macOS Travis CI image for newer Clang that is less picky about some newer C++20 features