### PR TITLE
Separate out workflows into CI / build release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,13 +13,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, windows-2019]
-        # has no effect on Windows, no problem
-        cxx: [clang++]
+        # specify a specific compiler to build with each OS separately
         include:
-          # override compiler when on Ubuntu to g++-10 (chooses g++-9 by default)
+          - os: macos-10.15
+            cxx: clang++
+            nickname: macos
+        include:
           - os: ubuntu-20.04
             cxx: g++-10
+            nickname: linux
+        include:
+          # NOTE: CXX seems to be ignored on Windows, but specify it anyway for consistency
+          - os: windows-2019
+            cxx: msvc
+            nickname: windows
 
     steps:
       - uses: actions/checkout@v2
@@ -51,5 +58,5 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v2
         with:
-          name: build_${{ github.sha }}_${{ matrix.os }}
+          name: build_${{ github.sha }}_${{ matrix.nickname }}
           path: ${{github.workspace}}/artifacts

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,9 +1,8 @@
 name: build-release
 
-# on:
-#   release:
-#     types: [published]
-on: push
+on:
+  release:
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [macos-10.15, windows-2019]
         # has no effect on Windows, no problem
-        cxx: clang++
+        cxx: [clang++]
         include:
           # override compiler when on Ubuntu to g++-10 (chooses g++-9 by default)
           - os: ubuntu-20.04

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -18,11 +18,9 @@ jobs:
           - os: macos-10.15
             cxx: clang++
             nickname: macos
-        include:
           - os: ubuntu-20.04
             cxx: g++-10
             nickname: linux
-        include:
           # NOTE: CXX seems to be ignored on Windows, but specify it anyway for consistency
           - os: windows-2019
             cxx: msvc

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,8 +1,6 @@
 name: build-release
 
-on:
-  release:
-    types: [published]
+on: push
 
 jobs:
   build:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,27 +1,23 @@
-name: continuous-integration
+name: build-release
 
-on: pull_request
+on:
+  release:
+    types: [published]
 
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     env:
-      BUILD_TYPE: Debug
+      BUILD_TYPE: Release
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, ubuntu-20.04]
-        cxx: [g++-10, clang++]
-        include:
-          - os: windows-2019
-            cxx: msvc
+        os: [macos-10.15, ubuntu-20.04, windows-2019]
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Configure CMake
-        env:
-          CXX: ${{ matrix.cxx }}
         # Use a bash shell so we can use the same syntax for environment variable
         # access regardless of the host operating system
         shell: bash
@@ -37,15 +33,14 @@ jobs:
         # Execute the build.  You can specify a specific target with "--target <NAME>"
         run: cmake --build . --config $BUILD_TYPE
 
-      - name: Test
+      - name: Install
         working-directory: ${{github.workspace}}/build
         shell: bash
-        # Execute tests defined by the CMake configuration.  
-        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-        run: ctest -C $BUILD_TYPE
-
-      - name: Test Install
-        working-directory: ${{github.workspace}}/build
-        shell: bash
-        # Test install with CMake to the "artifacts" directory
+        # Use CMake to "install" build artifacts (only interested in CMake registered targets) to our custom artifacts directory
         run: cmake --install . --config $BUILD_TYPE
+
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: build_${{ github.sha }}_${{ matrix.os }}
+          path: ${{github.workspace}}/artifacts

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,6 +1,8 @@
 name: build-release
 
-on: push
+on:
+  release:
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,8 +1,9 @@
 name: build-release
 
-on:
-  release:
-    types: [published]
+# on:
+#   release:
+#     types: [published]
+on: push
 
 jobs:
   build:
@@ -12,12 +13,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, ubuntu-20.04, windows-2019]
+        os: [macos-10.15, windows-2019]
+        # has no effect on Windows, no problem
+        cxx: clang++
+        include:
+          # override compiler when on Ubuntu to g++-10 (chooses g++-9 by default)
+          - os: ubuntu-20.04
+            cxx: g++-10
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Configure CMake
+        env:
+          CXX: ${{ matrix.cxx }}
         # Use a bash shell so we can use the same syntax for environment variable
         # access regardless of the host operating system
         shell: bash

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -15,16 +15,16 @@ jobs:
       matrix:
         # specify a specific compiler to build with each OS separately
         include:
-          - os: macos-10.15
-            cxx: clang++
-            nickname: macos
-          - os: ubuntu-20.04
+          - platform_name: linux
+            os: ubuntu-20.04
             cxx: g++-10
-            nickname: linux
+          - platform_name: macos
+            os: macos-10.15
+            cxx: clang++
           # NOTE: CXX seems to be ignored on Windows, but specify it anyway for consistency
-          - os: windows-2019
+          - platform_name: windows
+            os: windows-2019
             cxx: msvc
-            nickname: windows
 
     steps:
       - uses: actions/checkout@v2
@@ -56,5 +56,5 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v2
         with:
-          name: build_${{ github.sha }}_${{ matrix.nickname }}
+          name: build_${{ github.run_number }}_${{ matrix.platform_name }}
           path: ${{github.workspace}}/artifacts

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,6 @@
 name: continuous-integration
 
-on: pull_request
+on: push
 
 jobs:
   build:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-10.15, ubuntu-20.04]
-        # has no effect on Windows, no problem
         cxx: [g++-10, clang++]
         include:
           - os: windows-2019

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,7 +1,6 @@
 name: continuous-integration
 
-# on: pull_request
-on: push
+on: pull_request
 
 jobs:
   build:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,10 @@
 name: continuous-integration
 
-on: pull_request
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,7 @@
 name: continuous-integration
 
-on: pull_request
+# on: pull_request
+on: push
 
 jobs:
   build:
@@ -11,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-10.15, ubuntu-20.04]
+        # has no effect on Windows, no problem
         cxx: [g++-10, clang++]
         include:
           - os: windows-2019

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,6 @@
 name: continuous-integration
 
-on: push
+on: pull_request
 
 jobs:
   build:


### PR DESCRIPTION
- CI workflow is only built for pull requests
- Build Release workflow is only built for releases