### PR TITLE
Bugifx: corrected ommission of HTML document header in docs redirect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ else()
     set(MY_HOVERCRAFT_IS_FULL_OF_EELS_SUBPROJECT ON)
 endif()
 
-project(my-hovercraft-is-full-of-eels VERSION 0.4.0 LANGUAGES CXX)
+project(my-hovercraft-is-full-of-eels VERSION 0.4.1 LANGUAGES CXX)
 
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)

--- a/generate_index
+++ b/generate_index
@@ -11,6 +11,6 @@
 # pass version string for where the latest docs are as single parameter
 DOCS_VERSION=$1;
 # HTML template with DOCS_VERSION substituted
-HTML_FRAGMENT="<head><meta http-equiv='refresh' content='0; URL=${DOCS_VERSION}/'/></head><body><p>If you are not redirected in five seconds,<a href='${DOCS_VERSION}/'>click here</a>.</p></body>";
+HTML_FRAGMENT="<!DOCTYPE html><html lang='en'><head><meta http-equiv='refresh' content='0; URL=${DOCS_VERSION}/'/><title>Redirecting...</title></head><body><p>If you are not redirected in five seconds,<a href='${DOCS_VERSION}/'>click here</a>.</p></body></html>";
 # write out to the index HTML file that will appear at the root of Github Pages
 echo $HTML_FRAGMENT > "docs/index.html";


### PR DESCRIPTION
Browsers seem to be highly tolerant of malformed HTML code, hence why this oversight was not picked up in testing of the redirect feature.